### PR TITLE
Bd 412 enable multi sys environments

### DIFF
--- a/server/nodejs/config.js
+++ b/server/nodejs/config.js
@@ -1,7 +1,16 @@
 var config = {};
 
-//leave blank for default location of /root/.syscoin/ (must include trailing slash)
-config.sys_location = process.env.SYS_LOCATION || "/root/.syscoin/";
+//decide wether to use the live testnet or local isolated net
+if(process.env.ISOLATED){
+    //leave blank for default location of /root/.syscoin/ (must include trailing slash)
+    config.sys_location = process.env.SYS_ISO_LOCATION || "/root/.syscoin/";
+}
+else if(process.env.CONFIG){
+    config.sys_location = process.env.SYS_CONFIG_LOCATION || "/root/.syscoin/";
+}else{
+    //use in CONFIG mode by default
+    config.sys_location = process.env.SYS_CONFIG_LOCATION || "/root/.syscoin/";
+}
 
 config.debugEnabled = process.env.DEBUG || false;
 config.methodsWithLoggingDisabled = process.env.METHODS_WITH_LOGGING_DISABLED ? JSON.parse(process.env.METHODS_WITH_LOGGING_DISABLED) : [];


### PR DESCRIPTION
//connect to Syscoin regnet
`ISOLATED=true npm start`

//connect to Syscoin testnet
`CONFIG=true npm start`

//connect to testnet by default
`npm start`

new .env variables: (assume `key=value` pattern)
```
SYS_ISO_LOCATION='SYS_REGNET_CONFIG_VALUE'
SYS_CONFIG_LOCATION='SYS_TESTNET_CONFIG_VALUE'
```