### PR TITLE
Changes to package.json and config to allow for more robust operating.

### DIFF
--- a/server/nodejs/config.js
+++ b/server/nodejs/config.js
@@ -1,15 +1,34 @@
 var config = {};
 
-//decide wether to use the live testnet or local isolated net
-if(process.env.ISOLATED){
-    //leave blank for default location of /root/.syscoin/ (must include trailing slash)
-    config.sys_location = process.env.SYS_ISO_LOCATION || "/root/.syscoin/";
+var defaultSyscoinConfigLocation = "/root/.syscoin/"
+
+var setupIntegratedMode = (envArgument, envArgumentIdentifier, preamble, friendlyModeName) => {
+    console.log(`Running Syscoin API in '${friendlyModeName}' API run mode.\n${preamble}`);
+    if (envArgument) {
+        config.sys_location = envArgument;
+        console.log(`${envArgumentIdentifier} was set, using syscoin.conf path of '${config.sys_location}'`);
+    }
+    else {
+        config.sys_location = defaultSyscoinConfigLocation;
+        console.log(`Warning: SYSCOIN_CONFIG_ISOLATED_LOCATION was not set.  Check your .env file!`);
+        console.log(`Using default syscoin.conf path of '${defaultSyscoinConfigLocation}'`)
+    }
+};
+
+if (!process.env.APIRUNMODE) {
+    console.log(`Running Syscoin API without setting APIRUNMODE (should be 'isolated' or 'integrated').  Attempting to run in integrated mode.`);
+    setupIntegratedMode(process.env.SYSCOIN_CONFIG_INTEGRATED_LOCATION, 
+        "SYSCOIN_CONFIG_INTEGRATED_LOCATION",
+        `This is intended to be running off of an integrated instance (normally an official release) of syscoin.`,
+        `integrated`);
 }
-else if(process.env.CONFIG){
-    config.sys_location = process.env.SYS_CONFIG_LOCATION || "/root/.syscoin/";
-}else{
-    //use in CONFIG mode by default
-    config.sys_location = process.env.SYS_CONFIG_LOCATION || "/root/.syscoin/";
+else if (process.env.APIRUNMODE === 'isolated') {
+    setupIntegratedMode(process.env.SYSCOIN_CONFIG_ISOLATED_LOCATION, "SYSCOIN_CONFIG_ISOLATED_LOCATION",
+    `This is intended to be running off of an isolated instance (possibly custom build) of syscoin.`,`isolated`);
+}
+else if (process.env.APIRUNMODE === 'integrated') {
+    setupIntegratedMode(process.env.SYSCOIN_CONFIG_INTEGRATED_LOCATION, "SYSCOIN_CONFIG_INTEGRATED_LOCATION",
+    `This is intended to be running off of an integrated instance (normally an official release) of syscoin.`,`integrated`);
 }
 
 config.debugEnabled = process.env.DEBUG || false;
@@ -25,5 +44,7 @@ config.mongodb = {
   database_url: process.env.MONGODB_URL || "",
   offchain_url: "http://offchain-testnet.syscoin.org/aliasdata/"
 };
+
+
 
 module.exports = config;

--- a/server/nodejs/package.json
+++ b/server/nodejs/package.json
@@ -5,7 +5,9 @@
   "scripts": {
     "start": "node .",
     "startd": "pm2 start node . $CONFIG --name 'sys-api-server'",
-    "test": "mocha **/*.spec.js -R spec"
+    "test": "mocha **/*.spec.js -R spec",
+    "isolated": "APIRUNMODE=isolated node .",
+    "integrated": "APIRUNMODE=integrated node ."
   },
   "main": "index.js",
   "keywords": [


### PR DESCRIPTION
Using @quangogster's changes as a starting point and @ShahnawazAli93's request for some clarity, I've made a couple of tweaks:

a) the running now is a little more informative at startup so that a developer can be informed of what's going on vs. being "what's a syscoin.conf file?"
b) I've added the ability to simply do 'npm run isolated' and 'npm run integrated'.