### PR TITLE
Feature/aliasnewfund -> syscointxfund

### DIFF
--- a/server/nodejs/api/swagger.yaml
+++ b/server/nodejs/api/swagger.yaml
@@ -622,18 +622,18 @@ paths:
       - token: []
       x-swagger-router-controller: "Aliases"
     x-swagger-router-controller: "rpc"
-  /aliasnewfund:
+  /syscointxfund:
     post:
       tags:
       - "Aliases"
       description: "fund an alias creation"
-      operationId: "aliasnewfund"
+      operationId: "syscointxfund"
       parameters:
       - in: "body"
         name: "request"
         required: true
         schema:
-          $ref: "#/definitions/AliasNewFundRequest"
+          $ref: "#/definitions/SyscoinTransactionFundRequest"
       responses:
         200:
           description: "Success"
@@ -6503,7 +6503,7 @@ definitions:
       feedbackuserto: 5.63737665663332876420099637471139430999755859375
       _id: "_id"
       time: 6.02745618307040320615897144307382404804229736328125
-  AliasNewFundRequest:
+  SyscoinTransactionFundRequest:
     properties:
       hexstring:
         type: "string"

--- a/server/nodejs/controllers/Aliases.js
+++ b/server/nodejs/controllers/Aliases.js
@@ -36,9 +36,9 @@ module.exports.aliasupdatewhitelist = function aliasupdatewhitelist (req, res, n
   Aliases.aliasupdatewhitelist(req.swagger.params, res, next);
 };
 
-module.exports.aliasnewfund = function aliasnewfund (req, res, next) {
-  Aliases.aliasnewfund(req.swagger.params, res, next);
-};
+module.exports.syscointransactionfund = function syscointransactionfund(req, res, next) {
+  Aliases.syscointransactionfund(req.swagger.params, res, next)
+}
 
 module.exports.aliasaddscript = function aliasaddscript (req, res, next) {
   Aliases.aliasaddscript(req.swagger.params, res, next);

--- a/server/nodejs/controllers/AliasesService.js
+++ b/server/nodejs/controllers/AliasesService.js
@@ -186,26 +186,11 @@ exports.aliasupdatewhitelist = function(args, res, next) {
   syscoinClient.aliasUpdateWhitelist.apply(syscoinClient, arr);
 }
 
-exports.aliasnewfund = function(args, res, next) {
-  var argList = [
-    { prop: "hexstring" },
-    { prop: "addresses" }
-  ];
+exports.syscointransactionfund = methodGenerator.generateGenericSyscoinMethod([
+  { prop: 'hexstring' },
+  { prop: 'addresses' }
+], 'syscointxfund', syscoinClient.syscointxfund, 'POST');
 
-  var cb = function(err, result, resHeaders) {
-    res.setHeader('Content-Type', 'application/json');
-
-    if (err) {
-      return commonUtils.reportError(res, err);
-    }
-
-    console.log('aliasNewFund:', result);
-    res.end(JSON.stringify(result));
-  };
-
-  var arr = varUtils.getArgsArr(argList, args, "POST", cb);
-  syscoinClient.aliasNewFund.apply(syscoinClient, arr);
-}
 
 exports.aliasaddscript = function(args, res, next) {
   var argList = [

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -598,11 +598,11 @@ paths:
           schema:
             $ref: "#/definitions/ErrorResponse"
 
-  /aliasnewfund:
+  /syscointxfund:
     x-swagger-router-controller: rpc
     post:
-      operationId: aliasnewfund
-      description: fund an alias creation
+      operationId: syscointxfund
+      description: fund an alias creation (possibly other operations in the future)
       security:
       - token: []
       tags:
@@ -612,7 +612,7 @@ paths:
         in: body
         required: true
         schema:
-          $ref: "#/definitions/AliasNewFundRequest"
+          $ref: "#/definitions/SyscoinTransactionFundRequest"
       responses:
         "500":
           description: "Could not send raw transaction: Cannot decode transaction from hex string or No funds found in addresses provided "
@@ -5475,7 +5475,7 @@ definitions:
         type: number
       feedback:
         type: string
-  AliasNewFundRequest:
+  SyscoinTransactionFundRequest:
     properties:
       hexstring:
         type: string


### PR DESCRIPTION
Please see this and other accompanying PRs.  =) 

Please note there is a difference in naming behavior here that I'll highlight explicitly - this is to allow for a more descriptive name for the end consumer vs. the name that the RPC gives.